### PR TITLE
お問い合わせボタンのCSS変更 ほか

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -3,3 +3,5 @@ $indigo-1: #170f7b;
 $material-light: (
   'background': left 0 top 0/cover url(/BG.svg)
 );
+
+$btn-outline-border-width: 2px;

--- a/components/Contact.vue
+++ b/components/Contact.vue
@@ -17,7 +17,6 @@
 .Contact-Button {
   margin-right: auto;
   margin-left: auto;
-  width: 300px;
 
   &-Label {
     font-family: 'Noto Sans JP', sans-serif;

--- a/components/Contact.vue
+++ b/components/Contact.vue
@@ -8,7 +8,7 @@
       href="https://forms.gle/rxUU9V3CQ71MpZkZ6"
       target="_blank"
     >
-      お問い合わせ・取材依頼はこちら
+      <span class="Contact-Button-Label">お問い合わせ・取材依頼はこちら</span>
     </v-btn>
   </div>
 </template>
@@ -18,5 +18,12 @@
   margin-right: auto;
   margin-left: auto;
   width: 300px;
+
+  &-Label {
+    font-family: 'Noto Sans JP', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.93px;
+  }
 }
 </style>


### PR DESCRIPTION
- 元のデザイン案に合わせて、枠線の太さを `2px` に、フォントの太さを `600` に変更
- 中央揃えのために `width: 300px` を削除
- フォントがNoto Sans JPになってなかったので修正

![image](https://user-images.githubusercontent.com/34566290/87682465-d33c2480-c7ba-11ea-8a5e-e42042ecb144.png)
