### PR TITLE
width600px以下の端末の場合にエントリーボタンを220pxに縮小

### DIFF
--- a/components/ButtonEntry.vue
+++ b/components/ButtonEntry.vue
@@ -41,4 +41,13 @@ export default {
     margin-top: 6px;
   }
 }
+
+@media screen and (max-width: 600px) {
+  .ButtonEntry {
+    width: 220px;
+    &-Line1 {
+      font-size: 12px;
+    }
+  }
+}
 </style>


### PR DESCRIPTION
https://github.com/codeforjapan/CivictechCC-Website/pull/14#issuecomment-687699902
に対応
widthが600px以下の端末の場合、エントリーボタンを220px、フォントサイズを12pxに変更
これで被らない(はず)